### PR TITLE
fix: Upload acknowledgment logs were showing incorrect completion order because tasks were being processed sequentially rather than as they completed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ refresh:
 	@make up-dev
 
 lint:
-	@ruff check .
+	@black .
+	@ruff check . --fix
 
 format:
 	@black .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,12 @@ exclude = '''
 '''
 
 [tool.ruff]
-line-length = 88
+line-length = 100
 target-version = "py39"
 exclude = [".git", ".venv", "build", "dist"]
+
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
 fixable = ["E", "F", "W", "I"]
+ignore = ["E501"]

--- a/src/coordinator/__init__.py
+++ b/src/coordinator/__init__.py
@@ -1,1 +1,3 @@
 from .coordinator import Coordinator
+
+__all__ = ["Coordinator"]

--- a/src/coordinator/blob_storage.py
+++ b/src/coordinator/blob_storage.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from typing import Dict
 
 import httpx
 from fastapi import HTTPException

--- a/src/coordinator/coordinator.py
+++ b/src/coordinator/coordinator.py
@@ -1,10 +1,7 @@
 # src/coordinator/coordinator.py
-import asyncio
-import json
 import logging
-import uuid
-from datetime import datetime
-from typing import List, Dict
+from time import gmtime
+from typing import List
 
 from fastapi import HTTPException, UploadFile
 from redis import Redis
@@ -12,12 +9,11 @@ from redis import Redis
 from src.common.config import settings
 from src.common.interfaces import ICoordinator
 
+from .blob_storage import BlobStorage
 from .metadata_manager import MetadataManager
 from .node_manager import NodeManager
-from .blob_storage import BlobStorage
 from .repair_manager import RepairManager
 from .upload_manager import UploadManager
-from time import gmtime
 
 # https://stackoverflow.com/a/7517430/49489
 logging.basicConfig(

--- a/src/coordinator/metadata_manager.py
+++ b/src/coordinator/metadata_manager.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional
+
 from fastapi import HTTPException
 from redis import Redis
 

--- a/src/coordinator/node_manager.py
+++ b/src/coordinator/node_manager.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from datetime import datetime
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
 from fastapi import HTTPException
 from redis import Redis

--- a/src/coordinator/repair_manager.py
+++ b/src/coordinator/repair_manager.py
@@ -1,9 +1,9 @@
 import logging
 from typing import List
 
+from .blob_storage import BlobStorage
 from .metadata_manager import MetadataManager
 from .node_manager import NodeManager
-from .blob_storage import BlobStorage
 
 logger = logging.getLogger(__name__)
 

--- a/src/coordinator/upload_manager.py
+++ b/src/coordinator/upload_manager.py
@@ -2,13 +2,13 @@ import asyncio
 import logging
 import uuid
 from datetime import datetime
-from typing import List, Dict
+from typing import Dict, List
 
 from fastapi import HTTPException, UploadFile
 
+from .blob_storage import BlobStorage
 from .metadata_manager import MetadataManager
 from .node_manager import NodeManager
-from .blob_storage import BlobStorage
 from .repair_manager import RepairManager
 
 logger = logging.getLogger(__name__)
@@ -177,9 +177,9 @@ class UploadManager:
         successful_nodes = set()
         failed_nodes = set()
 
-        for task in tasks:
+        for completed_task in asyncio.as_completed(tasks):
             try:
-                result = await task
+                result = await completed_task
                 node_id = result["node_id"]
                 successful_nodes.add(node_id)
                 logger.info(

--- a/src/storage_node/api.py
+++ b/src/storage_node/api.py
@@ -1,8 +1,8 @@
 # src/storage_node/api.py
 import logging
 import os
-from typing import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 
 from fastapi import Depends, FastAPI, File, HTTPException, UploadFile
 

--- a/src/storage_node/node.py
+++ b/src/storage_node/node.py
@@ -61,7 +61,7 @@ class StorageNode(IStorageNode):
             if settings.NODE_DELAY > 0:
                 logger.info(f"Delaying for {settings.NODE_DELAY} seconds")
                 await asyncio.sleep(settings.NODE_DELAY)
-                logger.info(f"Delaying is over")
+                logger.info("Delaying is over")
             blob_path = Path(self.storage_dir) / blob_id
             file_size = 0
 


### PR DESCRIPTION
Upload acknowledgment logs were showing incorrect completion order because tasks were being processed sequentially rather than as they completed.

### Example of the Issue
```log
2025-02-16T14:34:05.799Z [httpx] HTTP Request: POST http://storage_node_2:8002/blob/3417d8c9-71fa-47d3-99e4-751e9d03e866 "HTTP/1.1 200 OK"
2025-02-16T14:34:05.799Z [src.coordinator.blob_storage] HTTP Request: POST http://storage_node_2:8002/blob/3417d8c9-71fa-47d3-99e4-751e9d03e866 "200 OK"
# Node 2 completed here but acknowledgment was delayed

2025-02-16T14:34:34.827Z [httpx] HTTP Request: POST http://storage_node_3:8003/blob/3417d8c9-71fa-47d3-99e4-751e9d03e866 "HTTP/1.1 200 OK"
# Had to wait ~29 seconds for node 3 before acknowledging node 2
2025-02-16T14:34:34.831Z [src.coordinator.upload_manager] Background upload succeeded for node 3. Total successful: 1
2025-02-16T14:34:34.831Z [src.coordinator.upload_manager] Background upload succeeded for node 2. Total successful: 2
```

## Fix
Changed `_process_remaining_tasks` in UploadManager to use `asyncio.as_completed()` instead of sequential task processing. This ensures uploads are acknowledged in the order they actually complete.

```python
- for task in tasks:  # Sequential processing
+ for completed_task in asyncio.as_completed(tasks):  # Process as they finish
    try:
-       result = await task
+       result = await completed_task
```